### PR TITLE
feat: add playback speed button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-videos-for-instagram",
   "displayName": "Better Videos for Instagram",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Easily control the playback and volume of Instagram videos.",
   "author": "Emir Kabal <me@emirkabal.com>",
   "scripts": {

--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -1,6 +1,7 @@
 import type { DownloadableMedia } from "~modules/Injector"
 
 import Autoskip from "./Controller/Buttons/Autoskip"
+import PlaybackSpeed from "./Controller/Buttons/PlaybackSpeed"
 // import DownloadButton from "./Controller/Buttons/Download"
 
 import "./Controller/style.css"
@@ -14,6 +15,7 @@ export default function Buttons({
 }) {
   return (
     <>
+      <PlaybackSpeed />
       <Autoskip />
       {/* {ctx.download && <DownloadButton data={ctx.download} />} */}
     </>

--- a/src/components/Controller/Buttons/PlaybackSpeed/SpeedometerIcon.tsx
+++ b/src/components/Controller/Buttons/PlaybackSpeed/SpeedometerIcon.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties } from "react"
+
+export default function SpeedometerIcon({
+  handStyle
+}: {
+  handStyle: CSSProperties
+}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M0.7 23A11.3 11.3 0 0 1 12 11.7 11.3 11.3 0 0 1 23.3 23"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      <path
+        d="M4.4 22.35a.72.72 0 1 1 0-1.44.72.72 0 0 1 0 1.44Z"
+        fill="currentColor"
+      />
+      <path
+        d="M19.6 22.35a.72.72 0 1 1 0-1.44.72.72 0 0 1 0 1.44Z"
+        fill="currentColor"
+      />
+      <g style={handStyle}>
+        <path
+          d="M12 23 12 14.5"
+          stroke="currentColor"
+          strokeWidth="1.9"
+          strokeLinecap="round"
+        />
+      </g>
+      <circle cx="12" cy="23" r="1.5" fill="currentColor" />
+    </svg>
+  )
+}

--- a/src/components/Controller/Buttons/PlaybackSpeed/index.tsx
+++ b/src/components/Controller/Buttons/PlaybackSpeed/index.tsx
@@ -1,0 +1,117 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties
+} from "react"
+import { useLocalStorage } from "usehooks-ts"
+
+import SpeedometerIcon from "./SpeedometerIcon"
+
+const SPEED_OPTIONS = [0.25, 0.5, 1, 1.25, 1.5, 2] as const
+
+const SPEED_ANGLE: Record<typeof SPEED_OPTIONS[number], number> = {
+  0.25: -90,
+  0.5: -45,
+  1: 0,
+  1.25: 22.5,
+  1.5: 45,
+  2: 90
+}
+
+export default function PlaybackSpeed() {
+  const id = useId()
+  const [playbackSpeed, setPlaybackSpeed] = useLocalStorage(
+    "bigv-playback-speed",
+    1
+  )
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (SPEED_OPTIONS.includes(playbackSpeed as (typeof SPEED_OPTIONS)[number]))
+      return
+    setPlaybackSpeed(1)
+  }, [playbackSpeed, setPlaybackSpeed])
+
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false)
+    }
+
+    document.addEventListener("pointerdown", onPointerDown)
+    document.addEventListener("keydown", onKeyDown)
+
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [])
+
+  const speed = useMemo(() => {
+    if (
+      SPEED_OPTIONS.includes(playbackSpeed as (typeof SPEED_OPTIONS)[number])
+    ) {
+      return playbackSpeed
+    }
+
+    return 1
+  }, [playbackSpeed])
+
+  const speedStyle = {
+    transform: `rotate(${SPEED_ANGLE[speed]}deg)`,
+    transformOrigin: "12px 23px",
+    transition: "transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1)"
+  } as CSSProperties
+
+  return (
+    <div className="bigv-playback-speed" ref={rootRef}>
+      <button
+        id={id}
+        type="button"
+        className="bigv-speed-button"
+        aria-label="Playback speed"
+        title={`Playback speed: ${speed}x`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}>
+        <SpeedometerIcon handStyle={speedStyle} />
+      </button>
+
+      <label htmlFor={id} className="bigv-switch-text bigv-speed-text">
+        {speed}x
+      </label>
+
+      {open && (
+        <div
+          className="bigv-speed-popup"
+          role="listbox"
+          aria-label="Playback speed">
+          {SPEED_OPTIONS.map((value) => (
+            <button
+              key={value}
+              role="option"
+              type="button"
+              className="bigv-speed-option"
+              aria-selected={speed === value}
+              data-active={speed === value}
+              onClick={() => {
+                setPlaybackSpeed(value)
+                setOpen(false)
+              }}>
+              {value}x
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Controller/index.tsx
+++ b/src/components/Controller/index.tsx
@@ -68,6 +68,7 @@ export default function Controller({
     "better-instagram-videos-muted",
     false
   )
+  const [playbackSpeed] = useLocalStorage("bigv-playback-speed", 1)
 
   // ig reels start
   // play, playing, seeking, waiting, volumechange, progress/timeupdate, seeked, canplay, playing, canplaythrough
@@ -91,7 +92,8 @@ export default function Controller({
 
   const play = useCallback(() => {
     updateAudio()
-  }, [updateAudio])
+    videoRef.current.playbackRate = playbackSpeed
+  }, [updateAudio, playbackSpeed])
 
   const ended = useCallback(() => {
     videoRef.current.currentTime = 0
@@ -125,6 +127,10 @@ export default function Controller({
   useEffect(() => {
     updateAudio()
   }, [videoRef, volume, muted])
+
+  useEffect(() => {
+    videoRef.current.playbackRate = playbackSpeed
+  }, [videoRef, playbackSpeed])
 
   useEffect(() => {
     if (dragging) videoRef.current.pause()

--- a/src/components/Controller/style.css
+++ b/src/components/Controller/style.css
@@ -66,12 +66,97 @@
   margin-bottom: 20px;
 }
 
-.bigv-buttons div {
+.bigv-buttons > div {
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   height: 44px;
+}
+
+.bigv-playback-speed {
+  position: relative;
+}
+
+.bigv-speed-button {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.95);
+  opacity: 0.92;
+  transition: opacity var(--animation-speed) ease;
+  cursor: pointer;
+}
+
+.bigv-speed-button:hover {
+  opacity: 1;
+}
+
+.bigv-speed-button svg {
+  width: 36px;
+  height: 36px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+}
+
+.bigv-speed-popup {
+  position: absolute;
+  right: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  min-width: 68px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 13px;
+  background: rgba(20, 20, 20, 0.26);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  box-shadow:
+    0 8px 28px rgba(0, 0, 0, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+
+.bigv-speed-option {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  border-radius: 10px;
+  margin: 0;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.bigv-speed-option:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.bigv-speed-option[data-active="true"] {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+}
+
+.bigv-speed-text {
+  color: rgba(255, 255, 255, 0.9);
+  margin-top: -6px;
+  line-height: 12px;
 }
 
 .bigv-switch {


### PR DESCRIPTION
Adds a new button giving the user control over playback speed: 0.25, 0.5, 1, 1.25, 1.5, 2

How it looks by default:
<img width="68" height="141" alt="image" src="https://github.com/user-attachments/assets/60b61d8b-8515-41fd-8000-a66db3cb0e31" />

Popout with 2x speed selected:
<img width="157" height="216" alt="image" src="https://github.com/user-attachments/assets/ce5d73c3-418a-4a08-8c26-306ed6c858a9" />

