### PR TITLE
fix: don't permanently persist forced mute during autoplay

### DIFF
--- a/src/components/Controller/index.tsx
+++ b/src/components/Controller/index.tsx
@@ -144,7 +144,6 @@ export default function Controller({
         "User has not interacted with the page yet. Muting video to allow autoplay."
       )
       video.muted = true
-      setMuted(true)
       return
     }
 
@@ -211,6 +210,31 @@ export default function Controller({
   useEffect(() => {
     updateAudio()
   }, [videoRef, volume, muted])
+
+  useEffect(() => {
+    if ("userActivation" in navigator && navigator.userActivation.hasBeenActive)
+      return
+
+    const handleFirstActivation = () => {
+      updateAudio()
+    }
+
+    document.addEventListener("pointerdown", handleFirstActivation, {
+      capture: true
+    })
+    document.addEventListener("keydown", handleFirstActivation, {
+      capture: true
+    })
+    document.addEventListener("touchstart", handleFirstActivation, {
+      capture: true
+    })
+
+    return () => {
+      document.removeEventListener("pointerdown", handleFirstActivation, true)
+      document.removeEventListener("keydown", handleFirstActivation, true)
+      document.removeEventListener("touchstart", handleFirstActivation, true)
+    }
+  }, [updateAudio])
 
   useEffect(() => {
     videoRef.current.playbackRate = playbackSpeed


### PR DESCRIPTION
## Summary
Fixes an issue where video sound would get permanently stuck muted.

## Problem
Instagram now autoplays reels via scrolling/autoskip without requiring a real click.
The extension's autoplay-safety logic muted >the video when the browser hadn't
detected user interaction yet, but it also **persisted** that muted state to
`localStorage` forever. As a result, sound never turned back on for the rest
of the session.

## Fix
The forced mute now only applies to the current autoplay attempt and is no
longer saved as the user's preference. As soon as the user interacts with the
page in any way (click, tap, keypress), the real saved audio preference is
re-applied automatically.